### PR TITLE
Import aliases

### DIFF
--- a/myalias/cli.py
+++ b/myalias/cli.py
@@ -2,6 +2,7 @@ import typer
 from rich.console import Console
 
 from myalias.commands.add_alias_command import AddAliasCommand
+from myalias.commands.import_aliases_command import ImportAliasesCommand
 from myalias.commands.list_alias_command import ListAliasCommand
 from myalias.commands.remove_alias_command import RemoveAliasCommand
 from myalias.core.commands.about_command import AboutCommand
@@ -66,6 +67,18 @@ def add_alias(name, description, command):
 
     """
     AddAliasCommand().execute(name, description, command)
+
+
+@app.command(name='import-aliases', rich_help_panel='Commands')
+def import_aliases(file_path):
+    """
+    Import list aliases to the application.
+    Args:
+        file_path (str): Path to aliases list file.
+
+    """
+    add_alias_command = AddAliasCommand()
+    ImportAliasesCommand(add_alias_command).execute(file_path)
 
 
 @app.command(name='remove-alias', rich_help_panel='Commands')

--- a/myalias/commands/import_aliases_command.py
+++ b/myalias/commands/import_aliases_command.py
@@ -1,0 +1,51 @@
+from rich.console import Console
+from rich.text import Text
+
+from myalias.core.interfaces.command_interface import CommandInterface
+from myalias.core.interfaces.service_interface import ServiceInterface
+from myalias.core.services.transform_file_into_tuples_list_service import (
+    TransformFileIntoTuplesListService,
+)
+
+
+class ImportAliasesCommand(CommandInterface):
+    """Import alias command."""
+
+    __add_alias_command: CommandInterface
+    __transform_file_into_tuples_list_service: ServiceInterface
+
+    def __init__(self, add_alias_command: CommandInterface):
+        self.__add_alias_command = add_alias_command
+        self.__transform_file_into_tuples_list_service = (
+            TransformFileIntoTuplesListService()
+        )
+
+    def execute(self, file_path):
+        """
+        Import a list of aliases command.
+
+        Args:
+            file_path (str): Path to aliases list file.
+
+        Returns:
+            Config not found.
+            Aliases imported successfully.
+        """
+
+        console = Console()
+
+        list_alias = self.__transform_file_into_tuples_list_service.execute(
+            file_path
+        )
+
+        if not list_alias:
+            console.print(Text('Config not found', 'red'))
+            return
+
+        for alias in list_alias:
+            name = alias[0]
+            console.print(Text(f'Adding alias {name}', 'yellow'))
+            self.__add_alias_command.execute(alias[0], alias[1], alias[2])
+            console.print(Text('\n'))
+
+        return

--- a/myalias/core/services/transform_file_into_tuples_list_service.py
+++ b/myalias/core/services/transform_file_into_tuples_list_service.py
@@ -25,7 +25,13 @@ class TransformFileIntoTuplesListService(ServiceInterface):
 
         with open(file_path, 'r') as file:
             for line in file:
-                alias, description, command = re.findall(r'"(.*?)"', line)
+                values = re.findall(r'"(.*?)"', line)
+
+                if len(values) != 3:
+                    continue
+
+                alias, description, command = values
+
                 tuples_list.append((alias, description, command))
 
         return tuples_list

--- a/myalias/core/services/transform_file_into_tuples_list_service.py
+++ b/myalias/core/services/transform_file_into_tuples_list_service.py
@@ -1,0 +1,31 @@
+import os
+import re
+
+from myalias.core.interfaces.service_interface import ServiceInterface
+
+
+class TransformFileIntoTuplesListService(ServiceInterface):
+    """Transform a file into a list fo tuples."""
+
+    def execute(self, file_path: str):
+        """
+        Transform a file into a list fo tuples.
+
+        Args:
+            file_path (str): Typer app.
+
+        Returns:
+            list: List of tuples.
+        """
+
+        tuples_list = []
+
+        if not os.path.exists(file_path):
+            return tuples_list
+
+        with open(file_path, 'r') as file:
+            for line in file:
+                alias, description, command = re.findall(r'"(.*?)"', line)
+                tuples_list.append((alias, description, command))
+
+        return tuples_list

--- a/myalias/core/services/transform_file_into_tuples_list_service.py
+++ b/myalias/core/services/transform_file_into_tuples_list_service.py
@@ -32,6 +32,8 @@ class TransformFileIntoTuplesListService(ServiceInterface):
 
                 alias, description, command = values
 
+                command = command.replace("'", '"')
+
                 tuples_list.append((alias, description, command))
 
         return tuples_list

--- a/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
+++ b/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
@@ -11,6 +11,7 @@ def test_transform_file_into_list_of_tuples():
         file.write('"myalias1" "description 1" "command 1"\n')
         file.write('"myalias2" "description 2" "command 2"\n')
         file.write('"myalias3" "description 3" "command 3"\n')
+        file.write('"myalias4" "description 4" "command \'4\'"\n')
 
     tuples_list = []
     with open(filename, 'r') as file:
@@ -22,13 +23,16 @@ def test_transform_file_into_list_of_tuples():
 
             alias, description, command = values
 
+            command = command.replace("'", '"')
+
             tuples_list.append((alias, description, command))
 
-    assert len(tuples_list) == 3
+    assert len(tuples_list) == 4
 
     assert tuples_list[0] == ('myalias1', 'description 1', 'command 1')
     assert tuples_list[1] == ('myalias2', 'description 2', 'command 2')
     assert tuples_list[2] == ('myalias3', 'description 3', 'command 3')
+    assert tuples_list[3] == ('myalias4', 'description 4', 'command "4"')
 
     os.remove(filename)
 

--- a/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
+++ b/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
@@ -1,0 +1,31 @@
+import os
+import re
+
+
+def test_transform_file_into_list_of_tuples():
+    filename = 'upload_file_test.txt'
+
+    with open(filename, 'w') as file:
+        file.write('"myalias1" "description 1" "command 1"\n')
+        file.write('"myalias2" "description 2" "command 2"\n')
+        file.write('"myalias3" "description 3" "command 3"\n')
+
+    tuples_list = []
+    with open(filename, 'r') as file:
+        for line in file:
+            alias, description, command = re.findall(r'"(.*?)"', line)
+            tuples_list.append((alias, description, command))
+
+    assert len(tuples_list) == 3
+
+    assert tuples_list[0] == ('myalias1', 'description 1', 'command 1')
+    assert tuples_list[1] == ('myalias2', 'description 2', 'command 2')
+    assert tuples_list[2] == ('myalias3', 'description 3', 'command 3')
+
+    os.remove(filename)
+
+
+def test_transform_inexists_file_into_list_of_tuples():
+    filename = 'upload_file_test.txt'
+
+    assert os.path.exists(filename) == False

--- a/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
+++ b/tests/myalias/core/services/test_transform_file_into_tuples_list_service.py
@@ -6,6 +6,8 @@ def test_transform_file_into_list_of_tuples():
     filename = 'upload_file_test.txt'
 
     with open(filename, 'w') as file:
+        file.write('###\n')
+        file.write('"###" "###" "###" "###"\n')
         file.write('"myalias1" "description 1" "command 1"\n')
         file.write('"myalias2" "description 2" "command 2"\n')
         file.write('"myalias3" "description 3" "command 3"\n')
@@ -13,7 +15,13 @@ def test_transform_file_into_list_of_tuples():
     tuples_list = []
     with open(filename, 'r') as file:
         for line in file:
-            alias, description, command = re.findall(r'"(.*?)"', line)
+            values = re.findall(r'"(.*?)"', line)
+
+            if len(values) != 3:
+                continue
+
+            alias, description, command = values
+
             tuples_list.append((alias, description, command))
 
     assert len(tuples_list) == 3


### PR DESCRIPTION
Adding a new command to add new aliases from a file that has a list.

## Usage
```plainText
# import_test_aliases
######
"ll" "lista de forma longa" "ls -l"
"la" "lista tudo" "ls -a"
"lla" "lista tudo de forma longa" "ls -la"
"ehello" "imprime hello" "echo hello" 
```
**Input:**
```bash
myalias import-aliases "any_directory/your_file_list"
```
**Output:**
![Captura de tela de 2024-02-28 23-21-04](https://github.com/thiagomeloo/myalias/assets/70541220/8b1c09e3-8fa3-4f75-ac5a-7e4f3933180c)
## Explanation
Basically, the command `import-aliases` recive the path to file and execute `ImportAliasesCommand`. Within this class, It's called the service `TransformFileIntoTuplesListService`, It reads the file and transforms into a list of tuples. Each tuples has exactly values to command `add-alias`, and then, `ImportAliasesCommand` iterates the list and executes `AddAliasCommand` to add commands.
**Obs.:** Just like the command `add-alias`, each lines on the import file are like passing param to command CLI.